### PR TITLE
Fix license enumeration bug

### DIFF
--- a/scripts/generate_sources.js
+++ b/scripts/generate_sources.js
@@ -197,7 +197,7 @@ function parseJson(json) {
             } else if (listCreditToUse === null) {
               listCreditToUse = creditToUse;
             }
-            for (license in creditToUse.licenses) {
+            for (const license of creditToUse.licenses) {
               if (!licensesFound.includes(license)) {
                 licensesFound.push(license);
               }


### PR DESCRIPTION
## Summary
- collect license names instead of indices in `generate_sources.js`

## Testing
- `node scripts/generate_sources.js`

------
https://chatgpt.com/codex/tasks/task_e_685071a0adfc832798c670e1c89318a0